### PR TITLE
Fix setrpaths to make sure files are writeable

### DIFF
--- a/setrpaths.sh
+++ b/setrpaths.sh
@@ -77,6 +77,7 @@ function patch_zip {
 	# Extract all and patch every binary file, and update the archive
 	unzip -q $fullname
 	for fname in $(find . -type f); do
+	        chmod u+w $fname
 		patch_rpath $fname;
 	done
 	zip -rq $fullname .


### PR DESCRIPTION
Fix setrpaths to make sure files from unzipped wheel are writeable before patching them.

@ccoulombe supposedly has this fix on his side and wanted to push it