### PR TITLE
Ensure ldd has all permissions

### DIFF
--- a/setrpaths.sh
+++ b/setrpaths.sh
@@ -78,7 +78,7 @@ function patch_zip {
 	unzip -q $fullname
 	for fname in $(find . -type f); do
 	        oldperm=$(stat --format %a $fname)
-	        chmod u+w $fname
+	        chmod u+rwx $fname
 		patch_rpath $fname;
 		chmod $oldperm $fname
 	done


### PR DESCRIPTION
When running `unmanylinuxize.py --package torchvision`, here is the end of the output:

```
...
Successfully downloaded torchvision
ldd: warning: you do not have execution permission for `./torchvision.libs/libpng16.7f72a3c5.so.16'
ldd: warning: you do not have execution permission for `./torchvision.libs/libjpeg.ceea7512.so.62'
ldd: warning: you do not have execution permission for `./torchvision.libs/libcudart.459720b2.so.10.2'
ldd: warning: you do not have execution permission for `./torchvision.libs/libz.1328edc3.so.1'
ldd: warning: you do not have execution permission for `./torchvision/image.so'
ldd: warning: you do not have execution permission for `./torchvision/_C.so'
/home/lemc2220/wheels/torchvision/tmp.15036
ldd: warning: you do not have execution permission for `./torchvision.libs/libpng16.7f72a3c5.so.16'
ldd: warning: you do not have execution permission for `./torchvision.libs/libjpeg.ceea7512.so.62'
ldd: warning: you do not have execution permission for `./torchvision.libs/libcudart.459720b2.so.10.2'
ldd: warning: you do not have execution permission for `./torchvision.libs/libz.1328edc3.so.1'
ldd: warning: you do not have execution permission for `./torchvision/image.so'
ldd: warning: you do not have execution permission for `./torchvision/_C.so'
/home/lemc2220/wheels/torchvision/tmp.15036
ldd: warning: you do not have execution permission for `./torchvision.libs/libpng16.7f72a3c5.so.16'
ldd: warning: you do not have execution permission for `./torchvision.libs/libjpeg.ceea7512.so.62'
ldd: warning: you do not have execution permission for `./torchvision.libs/libcudart.459720b2.so.10.2'
ldd: warning: you do not have execution permission for `./torchvision.libs/libz.1328edc3.so.1'
ldd: warning: you do not have execution permission for `./torchvision/image.so'
ldd: warning: you do not have execution permission for `./torchvision/_C.so'
/home/lemc2220/wheels/torchvision/tmp.15036
'torchvision-0.8.1-cp36-cp36m-linux_x86_64.whl' -> '../torchvision-0.8.1-cp36-cp36m-linux_x86_64.whl'
'torchvision-0.8.1-cp37-cp37m-linux_x86_64.whl' -> '../torchvision-0.8.1-cp37-cp37m-linux_x86_64.whl'
'torchvision-0.8.1-cp38-cp38-linux_x86_64.whl' -> '../torchvision-0.8.1-cp38-cp38-linux_x86_64.whl'
[lemc2220@build-node torchvision]$
```

This PR fixes that.