### PR TITLE
We can drop support for older compute and sm. 

### DIFF
--- a/config-gentoo.cfg
+++ b/config-gentoo.cfg
@@ -1,6 +1,6 @@
 [config]
 filter-deps = Bison,CMake=:3.16.5[,flex,ncurses,libreadline,gzip,bzip2,zlib,binutils,M4,Autoconf,Automake,libtool,Autotools,Szip,libxml2,SQLite,cURL,Doxygen,expat=:2.2.5[,Mesa,libGLU,SWIG=:3.0.12],PCRE,libjpeg-turbo,LibTIFF,libpng,XZ,gettext,X11,pkg-config,libdrm,gperf,FLTK,fontconfig,freetype,GMP,GL2PS,GraphicsMagick,MPFR,libmatheval,Tcl,Tk,libX11,libXft,libXpm,libXext,libXt,makedepend,cairo,libiconv,FFmpeg,GLib,FLANN,hwloc=:2.4.0[,numactl,DBus,texinfo,libsndfile,Pango,Lua,FreeImage,zstd,util-linux,file,GTK+,libunwind,LAME,NASM,x264,x265,FriBidi,ASSIMP,libarchive,ImageMagick,Ghostscript,Tkinter,libtirpc,Zip,SDL2,GST-plugins-base,libevent,tcsh,time,libedit,libpciaccess,UnZip,Check,OpenSSL,giflib,libwebp
 allow-loaded-modules=gentoo
-cuda-compute-capabilities = 3.5,3.7,5.0,6.0,7.0,7.5,8.0
+cuda-compute-capabilities = 6.0,7.0,7.5,8.0
 sysroot=/cvmfs/soft.computecanada.ca/gentoo/2020
 env-for-shebang = /cvmfs/soft.computecanada.ca/gentoo/2020/usr/bin/env -S


### PR DESCRIPTION
If one still requires to build for an older capability, one can override it at the command line.