### PR TITLE
Remove /cvmfs/.../easybuild/easyconfigs from robot-path

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -22,3 +22,4 @@ parallel = 8
 use-ccache=/cvmfs/local/ccache
 fixed-installdir-naming-scheme=False
 enforce-checksums = 1
+search-path = /cvmfs/soft.computecanada.ca/easybuild/easyconfigs

--- a/eb
+++ b/eb
@@ -86,7 +86,6 @@ elif [ "$(id -ng)" != "ebuser" ] ; then
 	export EASYBUILD_INSTALLPATH_SOFTWARE=/cvmfs/restricted.computecanada.ca/easybuild/$EASYBUILD_SUBDIR_SOFTWARE
 	export EASYBUILD_SOURCEPATH=/cvmfs/restricted.computecanada.ca/easybuild/sources
 fi
-export EASYBUILD_ROBOT_PATHS=$EASYBUILD_ROOT/easyconfigs:$EASYBUILD_ROBOT_PATHS
 if [[ -n "$USE_GENTOO" ]]; then
 	export EASYBUILD_HOOKS=$EASYBUILD_ROOT/cc_hooks_gentoo.py
 else
@@ -116,6 +115,16 @@ for argument in "$@"; do
 				echo "Please do not use a path to specify the easyconfig."
 				echo "Error on argument: $argument"
 				exit 1
+			else
+				# We want to prevent eb from using $EASYBUILD_ROOT/easyconfigs for
+				# dependencies so this is not in the robot path. To find the
+				# main easyconfig there we switch to its directory.
+				letter=${argument::1}
+				letter=${letter,} # lowercase first letter
+				name=${argument%%-*}
+				# some names contain - (e.g. HOOMD-blue) so we need pathname expansion
+				ec=$(echo "$EASYBUILD_ROOT/easyconfigs/$letter/$name"*"/$argument")
+				cd $(dirname $ec)
 			fi
 		fi
 	fi


### PR DESCRIPTION
This way dependencies are taken only from the archived easyconfigs
in ebfiles_repo.

To compensate:
1. eb (as ebuser only) cd's to the correct subdirectory of
/cvmfs/soft.computecanada.ca/easybuild/easyconfigs
where it can find the easyconfig.
2. search-path includes it so `eb -S` can find the file

as regular user the eb file is usually already in the current
directory