### PR TITLE
using the first 3 characters of sys.version won't work with python 3.10

### DIFF
--- a/python/site-packages/sitecustomize.py
+++ b/python/site-packages/sitecustomize.py
@@ -6,7 +6,8 @@ import site
 # virtualenv-installed packages
 
 if "EBPYTHONPREFIXES" in os.environ:
-    postfix = os.path.join('lib', 'python'+sys.version[:3], 'site-packages')
+    pv = ".".join([str(sys.version_info.major), str(sys.version_info.minor)])
+    postfix = os.path.join('lib', 'python'+pv], 'site-packages')
     for prefix in os.environ["EBPYTHONPREFIXES"].split(os.pathsep):
         sitedir = os.path.join(prefix, postfix)
         if os.path.isdir(sitedir):
@@ -27,7 +28,8 @@ def get_base_prefix():
 if get_base_prefix().startswith('/cvmfs/soft.computecanada.ca/nix/store/'):
     newprefix = os.environ.get("EBROOTPYTHON")
     if newprefix is not None:
-        postfix = os.path.join('lib', 'python'+sys.version[:3], 'site-packages')
+        pv = ".".join([str(sys.version_info.major), str(sys.version_info.minor)])
+        postfix = os.path.join('lib', 'python'+pv, 'site-packages')
         nixstoresitepackages = os.path.join(sys.prefix, postfix)
         if nixstoresitepackages in sys.path:
             site.addsitedir(os.path.join(newprefix, postfix))

--- a/python/site-packages/sitecustomize.py
+++ b/python/site-packages/sitecustomize.py
@@ -6,8 +6,7 @@ import site
 # virtualenv-installed packages
 
 if "EBPYTHONPREFIXES" in os.environ:
-    pv = ".".join([str(sys.version_info.major), str(sys.version_info.minor)])
-    postfix = os.path.join('lib', 'python'+pv], 'site-packages')
+    postfix = os.path.join('lib', 'python' + '.'.join(map(str, sys.version_info[:2])), 'site-packages')
     for prefix in os.environ["EBPYTHONPREFIXES"].split(os.pathsep):
         sitedir = os.path.join(prefix, postfix)
         if os.path.isdir(sitedir):
@@ -28,8 +27,7 @@ def get_base_prefix():
 if get_base_prefix().startswith('/cvmfs/soft.computecanada.ca/nix/store/'):
     newprefix = os.environ.get("EBROOTPYTHON")
     if newprefix is not None:
-        pv = ".".join([str(sys.version_info.major), str(sys.version_info.minor)])
-        postfix = os.path.join('lib', 'python'+pv, 'site-packages')
+        postfix = os.path.join('lib', 'python' + '.'.join(map(str, sys.version_info[:2])), 'site-packages')
         nixstoresitepackages = os.path.join(sys.prefix, postfix)
         if nixstoresitepackages in sys.path:
             site.addsitedir(os.path.join(newprefix, postfix))


### PR DESCRIPTION
this patch fixes that