### PR TITLE
add a mechanism to support EBPYTHONPREFIXES that takes priority over …

### DIFF
--- a/python/site-packages/sitecustomize.py
+++ b/python/site-packages/sitecustomize.py
@@ -5,6 +5,14 @@ import site
 # use prefixes from EBPYTHONPREFIXES, so they have lower priority than
 # virtualenv-installed packages
 
+if "EBPYTHONPREFIXES_PRIORITY" in os.environ:
+    postfix = os.path.join('lib', 'python' + '.'.join(map(str, sys.version_info[:2])), 'site-packages')
+    for prefix in os.environ["EBPYTHONPREFIXES_PRIORITY"].split(os.pathsep):
+        sitedir = os.path.join(prefix, postfix)
+        if os.path.isdir(sitedir):
+            sys.path.insert(0,sitedir)
+
+
 if "EBPYTHONPREFIXES" in os.environ:
     postfix = os.path.join('lib', 'python'+sys.version[:3], 'site-packages')
     for prefix in os.environ["EBPYTHONPREFIXES"].split(os.pathsep):


### PR DESCRIPTION
…python's default directories

implementing this would allow us to install the ctypes from https://github.com/ComputeCanada/custom_ctypes/commit/b3a0288f6e6174b502107a92ac8cd0db0842411b

and then support it by defining `EBPYTHONPREFIXES_PRIORITY` 

this is to help solve this issue https://github.com/ComputeCanada/software-stack/issues/100