### PR TITLE
Exclude clang of compiler family

### DIFF
--- a/cc_hooks_gentoo.py
+++ b/cc_hooks_gentoo.py
@@ -759,7 +759,7 @@ def set_modluafooter(ec):
     moduleclass = ec.get('moduleclass','')
     year = os.environ['EBVERSIONGENTOO']
     name = ec['name'].lower()
-    if moduleclass == 'compiler' and not name == 'gcccore' and not name == 'llvm':
+    if moduleclass == 'compiler' and not name in ('gcccore', 'llvm', 'clang'):
         if name in ['iccifort', 'intel-compilers']:
             name = 'intel'
         comp = os.path.join('Compiler', name + ec['version'][:ec['version'].find('.')])


### PR DESCRIPTION
In order to allow a module to be build with GCC but also depends on Clang.
e.g. TRIQS