### PR TITLE
Remove Catch2 overwrite no build dependencies. 

### DIFF
--- a/cc_hooks_gentoo.py
+++ b/cc_hooks_gentoo.py
@@ -334,9 +334,6 @@ opts_changes = {
     'BOLT-LMM': {
         'postinstallcmds': (['/cvmfs/soft.computecanada.ca/easybuild/bin/setrpaths.sh --path %(installdir)s '], REPLACE),
     },
-    'Catch2': {
-        'builddependencies': ([], REPLACE),
-    },
     'Clang': {
         'preconfigopts': ("""pushd %(builddir)s/llvm-%(version)s.src/tools/clang || pushd %(builddir)s/llvm-project-%(version)s.src/clang; """ +
                  # Use ${EPREFIX} as default sysroot


### PR DESCRIPTION
Remove Catch2 overwrite no build dependencies. 
It actually depends on CMake.

This fixes 
```
Changing builddependencies from: [('GCCcore', '8.3.0'), ('binutils', '2.32', '', ('GCCcore', '8.3.0')), ('CMake', '3.23.1', '', ('system', 'system'))] to: []
```
where overwriting buildependencies created an empty list for the CMake recipe, which in turns resulted in
```Error, for CMakeMake recipes, you should have a dependency on CMake.```

This goes with https://github.com/ComputeCanada/easybuild-easyconfigs/commit/f0be5c4c166e95ca7902b63d41587ff4cba5e97a