### PR TITLE
Error out when a symlink is provided as path.

### DIFF
--- a/setrpaths.sh
+++ b/setrpaths.sh
@@ -119,6 +119,12 @@ if [[ -z "$ARG_PATH" ]]; then
 	print_usage; exit 1
 fi
 
+# Avoid failing to set rpaths when a symlink is provided
+if [[ -L "$ARG_PATH" ]]; then
+	echo "error: $ARG_PATH is a symlink. Please provide a path not a symlink."
+	exit 1
+fi
+
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 for filename in $(find $ARG_PATH -type f); do


### PR DESCRIPTION
Since the find command do not follow symlinks, it may fail to set rpaths for needed SO. Make it explicit.

This avoids the following with Easybuild:
```
== 2023-02-22 14:57:02,651 run.py:648 INFO cmd "/cvmfs/soft.computecanada.ca/easybuild/bin/setrpaths.sh --path /home/coulombc/.local/easybuild/software/2020/avx2/Core/nlopt/2.7.1/lib/ --add_path /home/coulombc/.l
ocal/easybuild/software/2020/avx2/Core/nlopt/2.7.1/lib64" exited with exit code 0 and output:
find: /home/coulombc/.local/easybuild/software/2020/avx2/Core/nlopt/2.7.1/lib/: No such file or directory
```
where the `lib` is a symlink to `lib64` in the installation directory.

This errors explicitly and will make the build fail with a less puzzling information.