### PR TITLE
Use custom easyblocks in 2023.

### DIFF
--- a/2023/config.cfg
+++ b/2023/config.cfg
@@ -4,3 +4,4 @@ allow-loaded-modules=gentoo
 cuda-compute-capabilities = 6.0,7.0,7.5,8.0
 sysroot=/cvmfs/soft.computecanada.ca/gentoo/2023/x86-64-v3
 env-for-shebang = /cvmfs/soft.computecanada.ca/gentoo/2023/x86-64-v3/usr/bin/env -S
+include-easyblocks = /cvmfs/soft.computecanada.ca/easybuild/site-packages/custom-easyblocks/2023/easybuild/easyblocks/*/*.py


### PR DESCRIPTION
There are checked out at
/cvmfs/soft.computecanada.ca/easybuild/site-packages/custom-easyblocks/2023/easyblocks and correspond to the 2023 branch of the CC easybuild-easyblocks repository, in a similar fashion as
https://github.com/easybuilders/JSC/tree/2024/Custom_EasyBlocks