### PR TITLE
Let cc_hooks.py find cc_hooks_common.py by itself.

### DIFF
--- a/2017/cc_hooks.py
+++ b/2017/cc_hooks.py
@@ -2,9 +2,11 @@ from easybuild.framework.easyconfig.easyconfig import get_easyblock_class
 from easybuild.easyblocks.generic.cmakemake import CMakeMake
 from easybuild.framework.easyconfig.constants import EASYCONFIG_CONSTANTS
 from distutils.version import LooseVersion
+import sys, os
+parentdir = os.path.dirname(os.path.dirname(__file__))
+if parentdir not in sys.path:
+    sys.path.append(parentdir)
 from cc_hooks_common import modify_all_opts, update_opts, PREPEND, APPEND, REPLACE, APPEND_LIST
-
-import os
 
 # options to change in parse_hook, others are changed in other hooks
 PARSE_OPTS = ['modluafooter', 'postinstallcmds']

--- a/2020/cc_hooks.py
+++ b/2020/cc_hooks.py
@@ -6,13 +6,16 @@ from easybuild.toolchains.system import SystemToolchain
 from easybuild.toolchains.gcccore import GCCcore
 from easybuild.framework.easyconfig.constants import EASYCONFIG_CONSTANTS
 from distutils.version import LooseVersion
+import sys, os
+parentdir = os.path.dirname(os.path.dirname(__file__))
+if parentdir not in sys.path:
+    sys.path.append(parentdir)
 from cc_hooks_common import modify_all_opts, update_opts, PREPEND, APPEND, REPLACE, APPEND_LIST, DROP, DROP_FROM_LIST, REPLACE_IN_LIST
 from cc_hooks_common import get_matching_keys, get_matching_keys_from_ec
 from easybuild.tools.toolchain.utilities import search_toolchain
 from easybuild.tools.environment import setvar
 from easybuild.tools.run import run_cmd
 import uuid
-import os
 import shutil
 
 # options to change in parse_hook, others are changed in other hooks

--- a/2023/cc_hooks.py
+++ b/2023/cc_hooks.py
@@ -6,13 +6,16 @@ from easybuild.toolchains.system import SystemToolchain
 from easybuild.toolchains.gcccore import GCCcore
 from easybuild.framework.easyconfig.constants import EASYCONFIG_CONSTANTS
 from distutils.version import LooseVersion
+import sys, os
+parentdir = os.path.dirname(os.path.dirname(__file__))
+if parentdir not in sys.path:
+    sys.path.append(parentdir)
 from cc_hooks_common import modify_all_opts, update_opts, PREPEND, APPEND, REPLACE, APPEND_LIST, DROP, DROP_FROM_LIST, REPLACE_IN_LIST
 from cc_hooks_common import get_matching_keys, get_matching_keys_from_ec
 from easybuild.tools.toolchain.utilities import search_toolchain
 from easybuild.tools.environment import setvar
 from easybuild.tools.run import run_cmd
 import uuid
-import os
 import shutil
 
 # options to change in parse_hook, others are changed in other hooks

--- a/eb
+++ b/eb
@@ -101,7 +101,7 @@ export LC_ALL=en_US.UTF-8
 if [ ! -d /cvmfs/local ]; then
 	export EASYBUILD_USE_CCACHE=''
 fi
-export PYTHONPATH=$EASYBUILD_ROOT:$EASYBUILD_ROOT/site-packages
+export PYTHONPATH=$EASYBUILD_ROOT/site-packages
 export RSNT_EASYBUILD_MAGIC_COOKIE=263ca73bb634185aab1d1b41627fdbba
 
 # argument validation


### PR DESCRIPTION
This way we no longer rely on PYTHONPATH here and the path resolution is relative so cc_hooks_common.py can be tested more easily.