### PR TITLE
Adjust OPTARCH flags for GCC

### DIFF
--- a/eb
+++ b/eb
@@ -41,13 +41,21 @@ fi
 
 if [ "$RSNT_ARCH" == avx2 ]; then
 	if [ -n "$USE_GENTOO" ]; then
-	    export EASYBUILD_OPTARCH='NVHPC:tp=haswell;Intel:march=core-avx2 -axCore-AVX512;GCC:march=core-avx2'
+	    if [ "$YEAR" -ge 2023 ]; then
+		export EASYBUILD_OPTARCH='NVHPC:tp=haswell;Intel:march=core-avx2 -axCore-AVX512;GCC:march=x86-64-v3'
+	    else
+		export EASYBUILD_OPTARCH='NVHPC:tp=haswell;Intel:march=core-avx2 -axCore-AVX512;GCC:march=core-avx2'
+	    fi
 	else
 	    export EASYBUILD_OPTARCH='PGI:tp=haswell;Intel:xCore-AVX2;GCC:march=core-avx2'
 	fi
 elif [ "$RSNT_ARCH" == avx512 ]; then
 	if [ -n "$USE_GENTOO" ]; then
-	    export EASYBUILD_OPTARCH='NVHPC:tp=skylake;Intel:xCore-AVX512;GCC:march=skylake-avx512'
+	    if [ "$YEAR" -ge 2023 ]; then
+		export EASYBUILD_OPTARCH='NVHPC:tp=skylake;Intel:march=skylake-avx512;GCC:march=x86-64-v4'
+	    else
+		export EASYBUILD_OPTARCH='NVHPC:tp=skylake;Intel:xCore-AVX512;GCC:march=skylake-avx512'
+	    fi
 	else
 	    export EASYBUILD_OPTARCH='PGI:tp=skylake;Intel:xCore-AVX512;GCC:march=skylake-avx512'
 	fi


### PR DESCRIPTION
Use -march=x86-64-v3 and v4 for GCC. Intel is mostly unchanged for now because newer oneAPI compilers support these but not the classic compilers (but use -march in any case to support AMD Zen4).