### PR TITLE
Rename cuda-compat to cudacompat.

### DIFF
--- a/2023/cc_hooks.py
+++ b/2023/cc_hooks.py
@@ -395,7 +395,7 @@ opts_changes = {
         'postinstallcmds': (['/cvmfs/soft.computecanada.ca/easybuild/bin/setrpaths.sh --path %(installdir)s --add_origin'], APPEND_LIST),
         'modluafooter': ('''
 if cuda_driver_library_available("%(version_major_minor)s") == "compat" then
-        depends_on("cuda-compat/.%(version_major_minor)s")
+        depends_on("cudacompat/.%(version_major_minor)s")
 end
 ''', REPLACE)
     },


### PR DESCRIPTION
Following upstream naming convention.