### PR TITLE
Update cuDNN hook. Add cuda lib64 as rpath

### DIFF
--- a/2020/cc_hooks.py
+++ b/2020/cc_hooks.py
@@ -402,7 +402,7 @@ end
 ''', REPLACE)
     },
     'cuDNN': {
-        'postinstallcmds': (['/cvmfs/soft.computecanada.ca/easybuild/bin/setrpaths.sh --path %(installdir)s --add_path $CUDA_HOME/lib64 --add_origin'], APPEND_LIST),
+        'postinstallcmds': (['/cvmfs/soft.computecanada.ca/easybuild/bin/setrpaths.sh --path %(installdir)s --add_path $EBROOTCUDA/lib64 --add_origin'], APPEND_LIST),
     },
     'DB': {
         'configopts': ('--enable-cxx --enable-stl --enable-dbm', APPEND),

--- a/2023/cc_hooks.py
+++ b/2023/cc_hooks.py
@@ -365,7 +365,7 @@ end
 ''', REPLACE)
     },
     'cuDNN': {
-        'postinstallcmds': (['/cvmfs/soft.computecanada.ca/easybuild/bin/setrpaths.sh --path %(installdir)s --add_path $CUDA_HOME/lib64 --add_origin'], APPEND_LIST),
+        'postinstallcmds': (['/cvmfs/soft.computecanada.ca/easybuild/bin/setrpaths.sh --path %(installdir)s --add_path $EBROOTCUDA/lib64 --add_origin'], APPEND_LIST),
     },
     'DB': {
         'configopts': ('--enable-cxx --enable-stl --enable-dbm', APPEND),


### PR DESCRIPTION
Some cuDNN libraries requires `libcublas.so.11` and `libcublasLt.so.11`.
Add the current cuda lib64 to its rpath.