### PR TITLE
Updated hook to use 2023 java for any version

### DIFF
--- a/2023/cc_hooks.py
+++ b/2023/cc_hooks.py
@@ -56,7 +56,7 @@ new_version_mapping_2023a = {
         'Eigen': ('3.4.0', SYSTEM),
         ('GCCcore', '12.3.0'): ('12.3', SYSTEM, '-gentoo'),
         'GSL': ('2.7', COMPILERS_2023a),
-        ('Java', '11'): ('17', SYSTEM),
+        ('Java', 'ANY', ''): ('17', SYSTEM),
         ('HDF5','ANY',''): ('1.14.2', COMPILERS_2023a),
         ('HDF5','ANY',''): ('1.14.2', cOMPI_2023a, '-mpi'),
         ('HDF5','ANY','-mpi'): ('1.14.2', cOMPI_2023a, '-mpi'),


### PR DESCRIPTION
Help migrate 2020 recipes into 2023