### PR TITLE
if running through Slurm, use the maximum number of CPUs available to the job on the node

### DIFF
--- a/eb
+++ b/eb
@@ -172,6 +172,9 @@ for argument in "$@"; do
 		fi
 	fi
 done
+if [[ -n "$SLURM_CPUS_ON_NODE" ]]; then
+	export EASYBUILD_PARALLEL=$SLURM_CPUS_ON_NODE
+fi
 
 if [[ "$CURRENT_USER" == "ebuser" ]]; then
 	exec $EB --configfiles=$LOCAL_EASYBUILD_CONFIGFILES "${NEW_ARGS[@]}"


### PR DESCRIPTION
Without this, a job submitted with `--job-cores=16` will still only use `--parallel=8` as this is the default. This PR makes `--parallel` match the number of cores allocated by Slurm, while still keeping it possible to override (within an interactive job for example)