### PR TITLE
Use /cvmfs/local/tmp as tmpdir on Archimedes

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -1,5 +1,6 @@
 [config]
 buildpath = /tmp
+tmpdir = /cvmfs/local/tmp
 modules-tool = Lmod
 module-syntax = Lua
 prefix = /cvmfs/soft.computecanada.ca/easybuild

--- a/config.cfg
+++ b/config.cfg
@@ -1,6 +1,5 @@
 [config]
 buildpath = /tmp
-tmpdir = /cvmfs/local/tmp
 modules-tool = Lmod
 module-syntax = Lua
 prefix = /cvmfs/soft.computecanada.ca/easybuild

--- a/eb
+++ b/eb
@@ -15,6 +15,7 @@ if [[ $HOSTNAME =~ archimedes.c3.ca$ ]]; then
 	export SBATCH_MEM_PER_CPU='3500m'
 	export EASYBUILD_TMP_LOGDIR="/cvmfs/local/var/log"
 	export EASYBUILD_TMPDIR="/cvmfs/local/tmp"
+	export EASYBUILD_DISABLE_CLEANUP_TMPDIR=1
 fi
 EASYBUILD_ROOT=/cvmfs/soft.computecanada.ca/easybuild
 if [ -z "$USE_NIX" ]; then

--- a/eb
+++ b/eb
@@ -14,6 +14,7 @@ if [[ $HOSTNAME =~ archimedes.c3.ca$ ]]; then
 	export EASYBUILD_JOB_BACKEND='Slurm'
 	export SBATCH_MEM_PER_CPU='3500m'
 	export EASYBUILD_TMP_LOGDIR="/cvmfs/local/var/log"
+	export EASYBUILD_TMPDIR="/cvmfs/local/tmp"
 fi
 EASYBUILD_ROOT=/cvmfs/soft.computecanada.ca/easybuild
 if [ -z "$USE_NIX" ]; then


### PR DESCRIPTION
This is  so that temporary files such as tweaked EB are shared across all nodes