### PR TITLE
Avoid duplicate MODULEPATH for spider in CUDA-on-top-of-MPI modules

### DIFF
--- a/SoftCCHierarchicalMNS.py
+++ b/SoftCCHierarchicalMNS.py
@@ -286,14 +286,13 @@ class SoftCCHierarchicalMNS(HierarchicalMNS):
                     tc_cuda_name = tc_cuda['name'].lower()
                     tc_cuda_fullver = self.det_twodigit_version(tc_cuda)
                     subdir = os.path.join(subdir, tc_cuda_name+tc_cuda_fullver)
-                paths.append(os.path.join(prefix, subdir, ec['name'].lower()+fullver))
                 # CUDA on top of MPI instead of the old MPI on top of CUDA
                 tc_mpi = det_toolchain_mpi(ec)
                 if prefix == CUDA and tc_mpi is not None:
                     tc_mpi_name = tc_mpi['name'].lower()
                     tc_mpi_fullver = self.det_twodigit_version(tc_mpi)
                     subdir = os.path.join(subdir, tc_mpi_name+tc_mpi_fullver)
-                    paths.append(os.path.join(prefix, subdir, ec['name'].lower()+fullver))
+                paths.append(os.path.join(prefix, subdir, ec['name'].lower()+fullver))
 
         using2023 = 'EBROOTGENTOO' in os.environ and int(os.environ['EBVERSIONGENTOO']) >= 2023
         arch_dir = get_arch_dir(using2023, tc_comp_info)


### PR DESCRIPTION
CUDA-on-MPI adds both the MPI and Compiler CUDA MODULEPATHs, and CUDA-on-compiler only the Compiler one. This confuses `module spider`. So we need to guard it via a hook, and the MNS should only set the MPI MODULEPATH (the MNS isn't smart enough for this syntax, the hook needs to add it).

```
if (mode() ~= "spider") then
    prepend_path("MODULEPATH", pathJoin("/cvmfs/soft.computecanada.ca/easybuild/modules/2023/x86-64-v3/CUDA/gcc12/cuda12.2")
    if isDir(pathJoin(os.getenv("HOME"), ".local/easybuild/modules/2023/x86-64-v3/CUDA/gcc12/cuda12.2")) then
        prepend_path("MODULEPATH", pathJoin(os.getenv("HOME"), ".local/easybuild/modules/2023/x86-64-v3/CUDA/gcc12/cuda12.2"))
    end
end
```