### PR TITLE
Use srun --mpi=none with --job instead of default pmi2

### DIFF
--- a/eb
+++ b/eb
@@ -116,7 +116,7 @@ else
 	export PYTHONPATH=$EASYBUILD_ROOT/site-packages
 	EB=$EASYBUILD_ROOT/framework/eb
 fi
-export EASYBUILD_JOB_EB_CMD="srun --ntasks=1 $EB"
+export EASYBUILD_JOB_EB_CMD="srun --mpi=none --ntasks=1 $EB"
 export EASYBUILD_HOOKS=$EASYBUILD_CONFIG_ROOT/cc_hooks.py
 export EASYBUILD_BUILDPATH=$EASYBUILD_BUILDPATH/$RSNT_ARCH
 export LANG=en_US.UTF-8


### PR DESCRIPTION
PMI2 relies on a file descriptor that is closed by EB when calling subprocess functions to execute commands, thereby breaking singleton MPI executions in the GROMACS test suite.

PMI1, used with --mpi=none, doesn't have this issue (neither does PMIx, but PMIx is not available on Archimedes)