### PR TITLE
Since we handle rpath in our own linker wrapper, disable upstream

### DIFF
--- a/2023/config.cfg
+++ b/2023/config.cfg
@@ -8,3 +8,4 @@ include-easyblocks = /cvmfs/soft.computecanada.ca/easybuild/site-packages/custom
 trace=1
 map-toolchains=0
 job-cores=8
+rpath=0


### PR DESCRIPTION
EB's rpath functionality is the default in EB5