### PR TITLE
Added logic to add cuda compute cap. 10.0 when toolchain is 12.9.1 or greater

### DIFF
--- a/2023/cc_hooks.py
+++ b/2023/cc_hooks.py
@@ -16,7 +16,7 @@ if not os.path.exists(os.path.join(parentdir, 'cc_hooks_common.py')):
     sys.path.append('/cvmfs/soft.computecanada.ca/easybuild/easybuild-computecanada-config')
 from cc_hooks_common import modify_all_opts, update_opts, PREPEND, APPEND, REPLACE, APPEND_LIST, DROP, DROP_FROM_LIST, REPLACE_IN_LIST
 from cc_hooks_common import get_matching_keys, get_matching_keys_from_ec
-from easybuild.tools.config import build_option
+from easybuild.tools.config import build_option, update_build_option
 from easybuild.tools.toolchain.utilities import search_toolchain
 from easybuild.tools.environment import setvar
 from easybuild.tools.run import run_cmd, run_shell_cmd
@@ -942,6 +942,10 @@ def parse_hook(ec, *args, **kwargs):
         builddeps.append(('CUDAcore', '%(cudaver)s'))
     elif ec['toolchain'] == {'name': 'intel-compilers', 'version': '2023.1.0'}:
         ec['toolchain']['version'] = '2023.2.1'
+
+    if (('CUDAcore', '12.9.1') in builddeps or ec['toolchain'] == {'name': 'CUDAcore', 'version': '12.9.1'}):
+        if '10.0' not in build_option('cuda_compute_capabilities'):
+            update_build_option('cuda_compute_capabilities', build_option('cuda_compute_capabilities') + ['10.0'])
 
     # Use ifx by default as Fortran compiler for Intel toolchains.
     # Adapt optarch if oneapi compilers are used.

--- a/2023/cc_hooks.py
+++ b/2023/cc_hooks.py
@@ -943,9 +943,18 @@ def parse_hook(ec, *args, **kwargs):
     elif ec['toolchain'] == {'name': 'intel-compilers', 'version': '2023.1.0'}:
         ec['toolchain']['version'] = '2023.2.1'
 
+    ccc = build_option('cuda_compute_capabilities')
     if (('CUDAcore', '12.9.1') in builddeps or ec['toolchain'] == {'name': 'CUDAcore', 'version': '12.9.1'}):
-        if '10.0' not in build_option('cuda_compute_capabilities'):
-            update_build_option('cuda_compute_capabilities', build_option('cuda_compute_capabilities') + ['10.0'])
+        if '10.0' not in ccc:
+            print(f"Changing cuda compute capabilities from: {ccc} to {ccc + ['10.0']}")
+            update_build_option('cuda_compute_capabilities', ccc + ['10.0'])
+
+    # If it was added but the TC is not 12.9, remove it, like with --try-toolchain
+    elif ec['toolchain'] != {'name': 'CUDAcore', 'version': '12.9.1'} and ('CUDAcore', '12.9.1') not in builddeps:
+        if '10.0' in ccc:
+            print(f"Removing cuda compute capabilities 10.0")
+            ccc.remove('10.0')
+            update_build_option('cuda_compute_capabilities', ccc)
 
     # Use ifx by default as Fortran compiler for Intel toolchains.
     # Adapt optarch if oneapi compilers are used.

--- a/2023/cc_hooks.py
+++ b/2023/cc_hooks.py
@@ -944,17 +944,18 @@ def parse_hook(ec, *args, **kwargs):
         ec['toolchain']['version'] = '2023.2.1'
 
     ccc = build_option('cuda_compute_capabilities')
-    if (('CUDAcore', '12.9.1') in builddeps or ec['toolchain'] == {'name': 'CUDAcore', 'version': '12.9.1'}):
+    # For CUDA and CUDAcore, 12.9 or higher, add cuda compute 10.0
+    if (ec['toolchain'].get('name', '').startswith('CUDA') and ec['toolchain'].get('version', '').startswith(('12.9', '13.'))) or \
+        any(dep[0].startswith('CUDA') and dep[1].startswith(('12.9', '13.')) for dep in builddeps):
         if '10.0' not in ccc:
             print(f"Changing cuda compute capabilities from: {ccc} to {ccc + ['10.0']}")
             update_build_option('cuda_compute_capabilities', ccc + ['10.0'])
 
     # If it was added but the TC is not 12.9, remove it, like with --try-toolchain
-    elif ec['toolchain'] != {'name': 'CUDAcore', 'version': '12.9.1'} and ('CUDAcore', '12.9.1') not in builddeps:
-        if '10.0' in ccc:
-            print(f"Removing cuda compute capabilities 10.0")
-            ccc.remove('10.0')
-            update_build_option('cuda_compute_capabilities', ccc)
+    elif '10.0' in ccc:
+        print(f"Removing cuda compute capabilities 10.0")
+        ccc.remove('10.0')
+        update_build_option('cuda_compute_capabilities', ccc)
 
     # Use ifx by default as Fortran compiler for Intel toolchains.
     # Adapt optarch if oneapi compilers are used.

--- a/2023/cc_hooks.py
+++ b/2023/cc_hooks.py
@@ -944,9 +944,10 @@ def parse_hook(ec, *args, **kwargs):
         ec['toolchain']['version'] = '2023.2.1'
 
     ccc = build_option('cuda_compute_capabilities')
+    lower_bound_cudaver = LooseVersion('12.9.1')
     # For CUDA and CUDAcore, 12.9 or higher, add cuda compute 10.0
-    if (ec['toolchain'].get('name', '').startswith('CUDA') and ec['toolchain'].get('version', '').startswith(('12.9', '13.'))) or \
-        any(dep[0].startswith('CUDA') and dep[1].startswith(('12.9', '13.')) for dep in builddeps):
+    if (ec['toolchain'].get('name', '').startswith('CUDA') and LooseVersion(ec['toolchain'].get('version', -1)) >= lower_bound_cudaver) or \
+        any(dep[0].startswith('CUDA') and LooseVersion(dep[1]) >= lower_bound_cudaver for dep in builddeps):
         if '10.0' not in ccc:
             print(f"Changing cuda compute capabilities from: {ccc} to {ccc + ['10.0']}")
             update_build_option('cuda_compute_capabilities', ccc + ['10.0'])


### PR DESCRIPTION
When cuda 12.9.1 is used, add cuda compute capabiliy 10.0 to `--cuda-compute-capabilities` build option.