### PR TITLE
eb --bwrap: create tarball for result

### DIFF
--- a/eb
+++ b/eb
@@ -264,7 +264,14 @@ for rsnt_arch in $(IFS=","; echo $arch); do
 		bwrapdir=$(mktemp -d -p /bwrap)
 		echo "Building via bwrap in $bwrapdir"
 		bwrapcmd=$(RSNT_ARCH="$rsnt_arch" python $EASYBUILD_CONFIG_ROOT/../bwrapcmd.py $ec $bwrapdir)
-		$bwrapcmd $EB --installpath-modules=$bwrapdir/modules --configfiles=$LOCAL_EASYBUILD_CONFIGFILES "${NEW_ARGS[@]}" --ignore-locks
+		if $bwrapcmd $EB --installpath-modules=$bwrapdir/modules --configfiles=$LOCAL_EASYBUILD_CONFIGFILES "${NEW_ARGS[@]}" --ignore-locks; then
+		    tarcmd=$(RSNT_ARCH="$rsnt_arch" YEAR=$YEAR python $EASYBUILD_CONFIG_ROOT/../tarcmd.py $ec $bwrapdir)
+		    echo "Running $tarcmd"
+		    if $tarcmd; then
+			echo "removing $bwrapdir"
+			rm -rf $bwrapdir
+		    fi
+		fi
 	else
 		$EB --configfiles=$LOCAL_EASYBUILD_CONFIGFILES "${NEW_ARGS[@]}"
 	fi

--- a/tarcmd.py
+++ b/tarcmd.py
@@ -1,0 +1,28 @@
+import sys, os
+from easybuild.framework.easyconfig.easyconfig import process_easyconfig
+from easybuild.tools.options import set_up_configuration
+
+if __name__ == "__main__":
+    os.environ["EASYBUILD_LOGTOSTDOUT"] = "1"
+    os.environ["EASYBUILD_CONFIGFILES"] = os.environ["LOCAL_EASYBUILD_CONFIGFILES"]
+    os.environ["EASYBUILD_ROBOT_PATHS"] = os.pathsep.join((os.environ["EASYBUILD_ROBOT_PATHS"],
+                                                           os.path.join(os.environ["EBROOTGENTOO"],
+                                                                        "easybuild", "easyconfigs")))
+
+    old_stdout = sys.stdout
+    sys.stdout = open(os.devnull, "w")
+
+    set_up_configuration(args="")
+    parsed_ec = process_easyconfig(sys.argv[1])
+    bwrap_modules = [p['full_mod_name'] for p in parsed_ec]
+
+    bwrap_installpath = sys.argv[2]
+    tar_cmd = ['tar', 'cvf']
+
+    mod = bwrap_modules[0].split('/')
+    mod = mod[-2:] + mod[1:-2] + mod[:1]
+    tarball = os.path.join('/shared_tmp', f"{'_'.join(mod)}_{os.environ['YEAR']}_{os.environ['USER']}.tar")
+    tar_cmd.extend([tarball] + [os.path.join(bwrap_installpath, d) for d in ['modules', 'software']])
+
+    sys.stdout.close()
+    old_stdout.write(f'{" ".join(tar_cmd)}\n')

--- a/tarcmd.py
+++ b/tarcmd.py
@@ -22,8 +22,8 @@ if __name__ == "__main__":
     mod = bwrap_modules[0].split('/')
     mod = mod[-2:] + mod[1:-2] + mod[:1]
     tarball = os.path.join('/shared_tmp', f"{'-'.join(mod)}-{os.environ['YEAR']}-{os.environ['USER']}.tar")
-    tar_cmd.extend([tarball, '--owner=libuser'] +
-                   [os.path.join(bwrap_installpath, d) for d in ['modules', 'software']])
+    tar_cmd.extend([tarball, '--owner=libuser', f'--directory={bwrap_installpath}',
+                    'modules', 'software'])
 
     sys.stdout.close()
     old_stdout.write(f'{" ".join(tar_cmd)}\n')

--- a/tarcmd.py
+++ b/tarcmd.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
 
     mod = bwrap_modules[0].split('/')
     mod = mod[-2:] + mod[1:-2] + mod[:1]
-    tarball = os.path.join('/shared_tmp', f"{'_'.join(mod)}_{os.environ['YEAR']}_{os.environ['USER']}.tar")
+    tarball = os.path.join('/shared_tmp', f"{'-'.join(mod)}-{os.environ['YEAR']}-{os.environ['USER']}.tar")
     tar_cmd.extend([tarball, '--owner=libuser'] +
                    [os.path.join(bwrap_installpath, d) for d in ['modules', 'software']])
 

--- a/tarcmd.py
+++ b/tarcmd.py
@@ -22,7 +22,8 @@ if __name__ == "__main__":
     mod = bwrap_modules[0].split('/')
     mod = mod[-2:] + mod[1:-2] + mod[:1]
     tarball = os.path.join('/shared_tmp', f"{'_'.join(mod)}_{os.environ['YEAR']}_{os.environ['USER']}.tar")
-    tar_cmd.extend([tarball] + [os.path.join(bwrap_installpath, d) for d in ['modules', 'software']])
+    tar_cmd.extend([tarball, '--owner=libuser'] +
+                   [os.path.join(bwrap_installpath, d) for d in ['modules', 'software']])
 
     sys.stdout.close()
     old_stdout.write(f'{" ".join(tar_cmd)}\n')


### PR DESCRIPTION
The tarball is named like:
`/shared_tmp/quantumatk_2026.03_Core_x86-64-v3_2023_ebuser.tar` If all is successful the temporary directory under `/bwrap` is removed after creating the tarball.

It will then need to be fed to rsnt-sync on the publisher node (still to do)