### PR TITLE
Use rsnt_containers group to install containers

### DIFF
--- a/SoftCCHierarchicalMNS.py
+++ b/SoftCCHierarchicalMNS.py
@@ -30,6 +30,7 @@ Implementation of an example hierarchical module naming scheme.
 @author: Bart Oldeman  (Compute Canada)
 """
 
+import grp
 import os
 import re
 try:
@@ -212,6 +213,10 @@ class SoftCCHierarchicalMNS(HierarchicalMNS):
 
         :return: string with name of subdirectory, e.g.: '<compiler>/<mpi_lib>/<name>/<version>'
         """
+        # special handling for containers
+        if grp.getgrgid(os.getegid()).gr_name == 'rsnt_containers':
+            subdir = os.path.join("containers", f"{ec['name']}-{ec['version']}".lower())
+            return subdir
         # by default: use full module name as name for install subdir
         # only use gcccore-hidden for module name, not the install subdir
         subdir = self.det_module_subdir(ec)

--- a/eb
+++ b/eb
@@ -98,7 +98,11 @@ else
 		echo "Failed to read \$HOME/.git_env_vars.sh. Please make sure they are readable and configured as described on https://wiki.alliancecan.ca/wiki/RSNT_Software_-_Setting_up#Configuring_your_build_node_account"
 		exit 1
 	fi
-	if [ "$(id -ng)" != "ebuser" ] ; then
+	if [ "$(id -ng)" == "rsnt_containers" ] ; then
+		export EASYBUILD_INSTALLPATH_SOFTWARE=/cvmfs/containers.computecanada.ca/content
+		export EASYBUILD_SUBDIR_SOFTWARE=''
+		use_bwrap=1
+	elif [ "$(id -ng)" != "ebuser" ] ; then
 		# using ebuser with different group ID
 		export EASYBUILD_INSTALLPATH_SOFTWARE=/cvmfs/restricted.computecanada.ca/easybuild/$EASYBUILD_SUBDIR_SOFTWARE
 		export EASYBUILD_SOURCEPATH=/cvmfs/restricted.computecanada.ca/easybuild/sources

--- a/tarcmd.py
+++ b/tarcmd.py
@@ -22,8 +22,12 @@ if __name__ == "__main__":
     mod = bwrap_modules[0].split('/')
     mod = mod[-2:] + mod[1:-2] + mod[:1]
     tarball = os.path.join('/shared_tmp', f"{'-'.join(mod)}-{os.environ['YEAR']}-{os.environ['USER']}.tar")
-    tar_cmd.extend([tarball, '--owner=libuser', f'--directory={bwrap_installpath}',
-                    'modules', 'software'])
+    if os.path.exists(os.path.join(bwrap_installpath, 'containers')):
+        tar_cmd.extend([tarball, '--owner=libuser-containers', f'--directory={bwrap_installpath}',
+                        'modules', 'containers'])
+    else:
+        tar_cmd.extend([tarball, '--owner=libuser', f'--directory={bwrap_installpath}',
+                        'modules', 'software'])
 
     sys.stdout.close()
     old_stdout.write(f'{" ".join(tar_cmd)}\n')


### PR DESCRIPTION
Using `sudo -iu ebuser -g rsnt_containers eb ...`
instead of a path in the easyconfig, mimicking the restricted logic.

This helps to make it work with upstream `--bwrap`. The eb script needs to set
`EASYBUILD_INSTALLPATH_SOFTWARE=/cvmfs/containers.computecanada.ca/content` and then the MNS sets the subdirectory, e.g.
`containers/qiime-2026.4`
so the install dir is set corrrectly.

Then the tarball creation needs to be aware of this containers directory, instead of `software`.